### PR TITLE
Adding Enabled Field and Remove Schedule Config

### DIFF
--- a/slack/km/connector/slackChannelsConnector.json
+++ b/slack/km/connector/slackChannelsConnector.json
@@ -7,7 +7,8 @@
     "sourceConfig": {
       "apiPushConfig": {
         "app": "58757",
-        "dataFormat": "JSON"
+        "dataFormat": "JSON",
+        "enabled": true
       }
     },
     "baseSelector": {
@@ -174,9 +175,5 @@
       "header": "Number of Members",
       "subfieldPath": []
     }
-  ],
-  "scheduleConfig": {
-    "useSourceSchedule": true,
-    "runMode": "DEFAULT"
-  }
+  ]
 }

--- a/slack/km/connector/slackMessagesConnector.json
+++ b/slack/km/connector/slackMessagesConnector.json
@@ -7,7 +7,8 @@
     "sourceConfig": {
       "apiPushConfig": {
         "app": "58757",
-        "dataFormat": "JSON"
+        "dataFormat": "JSON",
+        "enabled": true
       }
     },
     "baseSelector": {
@@ -237,9 +238,5 @@
         }
       ]
     }
-  ],
-  "scheduleConfig": {
-    "useSourceSchedule": true,
-    "runMode": "DEFAULT"
-  }
+  ]
 }

--- a/slack/km/connector/slackUsersConnector.json
+++ b/slack/km/connector/slackUsersConnector.json
@@ -7,7 +7,8 @@
     "sourceConfig": {
       "apiPushConfig": {
         "app": "58757",
-        "dataFormat": "JSON"
+        "dataFormat": "JSON",
+        "enabled": true
       }
     },
     "baseSelector": {
@@ -198,9 +199,5 @@
       "header": "Last Updated",
       "subfieldPath": []
     }
-  ],
-  "scheduleConfig": {
-    "useSourceSchedule": true,
-    "runMode": "DEFAULT"
-  }
+  ]
 }


### PR DESCRIPTION
Schedule Configurations will soon be removed from all push connectors
with added validation preventing it. Adding enabled flag which will
be used when pushing data - the enabled flag uses the boolean from
use source schedule
